### PR TITLE
Handle font urls with #? characters

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -1,7 +1,7 @@
 var path = require("path");
 var regexAll = require("./regex_all");
 
-var urlExp = /url\(["']?(.+?)["']?\)/g;
+var urlExp = /url\(["']?(.+?)[?#"')]/g;
 
 exports.find = function(bundle){
 	var nodes = bundle.nodes || [];

--- a/lib/inferred.js
+++ b/lib/inferred.js
@@ -24,7 +24,7 @@ function bundleAssets(buildResult, options){
 		var handler = handlers[buildType];
 
 		if(handler) {
-			var assets = uniq(handler.find(bundle));
+			var assets = uniq(handler.find(bundle), "path");
 			assets.forEach(function(asset){
 				asset.src = path.join(path.dirname(bundlePath), asset.path);
 				asset.dest = path.join(bundlePath, asset.path);

--- a/test/basics/styles.css
+++ b/test/basics/styles.css
@@ -1,7 +1,9 @@
 @font-face {
 	font-family: foo;
 	src: url('fonts/foo.eot');
-	src: url('fonts/foo.woff') format('woof2');
+	src: url('fonts/foo.woff') format('woof2'),
+		url('fonts/foo.eot?#iefix') format('embedded-opentype'),
+		url('fonts/foo.svg#glyphicons_half') format('svg');
 }
 
 body {

--- a/test/test.js
+++ b/test/test.js
@@ -55,6 +55,10 @@ describe("inferred from source content", function(){
 			exists(__dirname + "/basics/dist/fonts/foo.woff"),
 			"woff font moved"
 		);
+		assert(
+			exists(__dirname + "/basics/dist/fonts/foo.svg"),
+			"svg font moved"
+		);
 	});
 
 });


### PR DESCRIPTION
Some font urls might contain the characters `#` or `?` or both like:

```css
  src: url('fonts/foo.woff') format('woof2'),
    url('fonts/foo.eot?#iefix') format('embedded-opentype'),
    url('fonts/foo.svg#glyphicons_half') format('svg');
```

This updates the regex to handle these.