### PR TITLE
Move assets once when there are multiple bundles

### DIFF
--- a/lib/inferred.js
+++ b/lib/inferred.js
@@ -15,6 +15,7 @@ var pluginExp = /\!.*/;
 function bundleAssets(buildResult, options){
 	var bundlesPath = buildResult.configuration.bundlesPath;
 	var bundles = buildResult.bundles;
+	var movedAssets = [];
 
 	var promises = bundles.map(function(bundle){
 		var buildType = bundle.buildType;
@@ -25,14 +26,19 @@ function bundleAssets(buildResult, options){
 
 		if(handler) {
 			var assets = uniq(handler.find(bundle), "path");
+			var toMove = [];
 			assets.forEach(function(asset){
 				asset.src = path.join(path.dirname(bundlePath), asset.path);
 				asset.dest = path.join(bundlePath, asset.path);
-
+				// Maintain a list of assets that have been moved so we only move them once
+				if(movedAssets.indexOf(asset.dest) === -1) {
+					toMove.push(asset);
+					movedAssets.push(asset.dest);
+				}
 			});
 
 			// move around the assets
-			return moveAssets(assets).then(function(){
+			return moveAssets(toMove).then(function(){
 				// rewrite the original bundle content so that the urls
 				// are pointed at the correct, production, location.
 				return rewriteContent(bundle, bundlePath, handler, assets);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "is-there": "^4.0.0",
     "mocha": "^2.2.5",
+    "sinon": "^1.17.4",
     "steal": "^0.10.5",
     "steal-tools": "^0.11.0-pre.3"
   }

--- a/test/basics/home.css
+++ b/test/basics/home.css
@@ -1,0 +1,11 @@
+@font-face {
+	font-family: foo;
+	src: url('fonts/foo.eot');
+	src: url('fonts/foo.woff') format('woof2'),
+		url('fonts/foo.eot?#iefix') format('embedded-opentype'),
+		url('fonts/foo.svg#glyphicons_half') format('svg');
+}
+
+body.home {
+	background: url("images/logo.png");
+}

--- a/test/basics/home.js
+++ b/test/basics/home.js
@@ -1,0 +1,1 @@
+require("./home.css!");


### PR DESCRIPTION
When there are multiple bundles that share some of the same assets, steal-bundler will attempt to move these assets multiple times, sometimes causing the bundling to fail because the copy operations are colliding (one copy operation is unlinking a file while another is performing some other operation on it).

I was able to make this happen 100% with font files.

The solution is to keep a list of assets that have been moved so each file is only moved once. Since the destination is the exact same for all assets, this should not cause problems.

**Also note this only occurs when steal-bundler is inferring the assets.**