### PR TITLE
Do not match directories

### DIFF
--- a/lib/globbed.js
+++ b/lib/globbed.js
@@ -8,10 +8,11 @@ module.exports = bundleAssets;
 
 function bundleAssets(buildResult, options){
 	var globs = toArray(options.glob);
+	var globOpts = { nodir: true };
 
 	var promises = globs.map(function(pattern){
 
-		return asap(glob)(pattern).then(function(files){
+		return asap(glob)(pattern, globOpts).then(function(files){
 
 			return Promise.all(copyFiles(buildResult, files));
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "is-there": "^4.0.0",
     "mocha": "^2.2.5",
     "sinon": "^1.17.4",
-    "steal": "^1.0.0-rc.0",
-    "steal-tools": "^1.0.0-rc.0"
+    "steal": "^1.0.0",
+    "steal-tools": "^1.0.0"
   }
 }

--- a/test/basics/home.js
+++ b/test/basics/home.js
@@ -1,1 +1,1 @@
-require("./home.css!");
+require("./home.css");

--- a/test/basics/main.js
+++ b/test/basics/main.js
@@ -1,1 +1,1 @@
-require("./styles.css!");
+require("./styles.css");

--- a/test/basics/node_modules/steal-css/css.js
+++ b/test/basics/node_modules/steal-css/css.js
@@ -1,0 +1,223 @@
+var loader = require("@loader");
+var steal = require("@steal");
+
+var isNode = typeof process === "object" && {}.toString.call(process) ===
+	"[object process]";
+var importRegEx = /@import [^uU]['"]?([^'"\)]*)['"]?/g;
+var resourceRegEx =  /url\(['"]?([^'"\)]*)['"]?\)/g;
+
+var waitSeconds = (loader.cssOptions && loader.cssOptions.timeout)
+	? parseInt(loader.cssOptions.timeout, 10) : 60;
+var noop = function () {};
+var onloadCss = function(link, cb){
+	var styleSheets = getDocument().styleSheets,
+		i = styleSheets.length;
+	while( i-- ){
+		if( styleSheets[ i ].href === link.href ){
+			return cb();
+		}
+	}
+	setTimeout(function() {
+		onloadCss(link, cb);
+	});
+};
+
+function getDocument() {
+	if(typeof doneSsr !== "undefined" && doneSsr.globalDocument) {
+		return doneSsr.globalDocument;
+	}
+
+	return typeof document === "undefined" ? undefined : document;
+}
+
+function getHead() {
+	var doc = getDocument();
+	var head = doc.head || doc.getElementsByTagName("head")[0];
+
+	if(!head) {
+		var docEl = doc.documentElement || doc;
+		head = doc.createElement("head");
+		docEl.insertBefore(head, docEl.firstChild);
+	}
+	return head;
+}
+
+/**
+ *
+ */
+function CSSModule(address, source) {
+	this.address = address;
+	this.source = source;
+}
+
+CSSModule.prototype = {
+	injectLink: function(){
+		if(this._loaded) {
+			return this._loaded;
+		}
+
+		if(this.linkExists()) {
+			this._loaded = Promise.resolve('');
+			return this._loaded;
+		}
+
+		// inspired by https://github.com/filamentgroup/loadCSS
+		var doc = getDocument();
+		var styleSheets = doc.styleSheets;
+		var address = this.address;
+		var link = this.link = doc.createElement("link");
+		link.type = "text/css";
+		link.rel = "stylesheet";
+		link.href = this.address;
+
+		// wait until the css file is loaded
+		this._loaded = new Promise(function(resolve, reject) {
+			var timeout = setTimeout(function() {
+				reject('Unable to load CSS');
+			}, waitSeconds * 1000);
+
+			var loadCB = function(event) {
+				clearTimeout(timeout);
+				link.removeEventListener("load", loadCB);
+				link.removeEventListener("error", loadCB);
+
+				if(event && event.type === "error"){
+					reject('Unable to load CSS');
+				} else {
+					resolve('');
+				}
+			};
+
+			// This code is for browsers that don’t support onload
+			// No support for onload (it'll bind but never fire):
+			//	* Android 4.3 (Samsung Galaxy S4, Browserstack)
+			//	* Android 4.2 Browser (Samsung Galaxy SIII Mini GT-I8200L)
+			//	* Android 2.3 (Pantech Burst P9070)
+			// Weak inference targets Android < 4.4 and
+			// a fallback for IE 8 and beneath
+			if( "isApplicationInstalled" in navigator ||
+			   !link.addEventListener) {
+				// fallback, polling styleSheets
+				onloadCss(link, loadCB);
+			} else {
+				// attach onload event for all modern browser
+				link.addEventListener( "load", loadCB );
+				link.addEventListener( "error", loadCB );
+			}
+
+			getHead().appendChild(link);
+		});
+
+		return this._loaded;
+	},
+
+
+	injectStyle: function(){
+		var doc = getDocument();
+		var head = getHead();
+		var style = this.style = doc.createElement('style');
+
+		// make source load relative to the current page
+		style.type = 'text/css';
+
+		if (style.styleSheet){
+			style.styleSheet.cssText = this.source;
+		} else {
+			style.appendChild(doc.createTextNode(this.source));
+		}
+		head.appendChild(style);
+	},
+
+	// Replace @import's that don't start with a "u" or "U" and do start
+	// with a single or double quote with a path wrapped in "url()"
+	// relative to the page
+	updateURLs: function(){
+		var rawSource = this.source,
+			address = this.address;
+
+		this.source = rawSource.replace(importRegEx, function(whole, part){
+			if(isNode) {
+				return "@import url(" + part + ")";
+			}else{
+				return "@import url(" + steal.joinURIs(address, part) + ")";
+			}
+		});
+
+		if(!isNode) {
+			this.source = this.source + "/*# sourceURL=" + address + " */";
+			this.source = this.source.replace(resourceRegEx, function(whole, part){
+				return "url(" + steal.joinURIs(address, part) + ")";
+			});
+
+		}
+		return this.source;
+	},
+
+	getExistingNode: function(){
+		var doc = getDocument();
+		var selector = "[href='" + this.address + "']";
+		return doc.querySelector && doc.querySelector(selector);
+	},
+
+	linkExists: function(){
+		var styleSheets = getDocument().styleSheets;
+		for (var i = 0; i < styleSheets.length; ++i) {
+			if(this.address === styleSheets[i].href){
+				return true;
+			}
+		}
+		return false;
+	},
+
+	setupLiveReload: function(loader, name){
+		var head = getHead();
+
+		if(loader.liveReloadInstalled) {
+			var cssReload = loader["import"]("live-reload", {
+				name: module.id
+			});
+
+			Promise.resolve(cssReload).then(function(reload){
+				loader["import"](name).then(function(){
+					reload.once(name, function(){
+						head.removeChild(css.style);
+					});
+				});
+			});
+		}
+	}
+};
+
+
+if(loader.isEnv("production")) {
+	exports.fetch = function(load) {
+		var css = new CSSModule(load.address);
+		return css.injectLink();
+	};
+} else {
+	exports.instantiate = function(load) {
+		var loader = this;
+
+		var css = new CSSModule(load.address, load.source);
+		load.source = css.updateURLs();
+
+		load.metadata.deps = [];
+		load.metadata.format = "css";
+		load.metadata.execute = function(){
+			if(getDocument()) {
+				css.injectStyle();
+				css.setupLiveReload(loader, load.name);
+			}
+
+			return loader.newModule({
+				source: css.source
+			});
+		};
+	};
+
+}
+
+exports.CSSModule = CSSModule;
+exports.locateScheme = true;
+exports.buildType = "css";
+exports.includeInBuild = true;

--- a/test/basics/node_modules/steal-css/package.json
+++ b/test/basics/node_modules/steal-css/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "steal-css",
+  "version": "1.0.0",
+  "description": "CSS plugin for StealJS",
+  "main": "css.js",
+  "steal": {
+	"ext": {
+		"css": "steal-css"
+	}
+  }
+}

--- a/test/basics/package.json
+++ b/test/basics/package.json
@@ -1,5 +1,13 @@
 {
 	"name": "basics",
 	"version": "1.0.0",
-	"main": "main.js"
+	"main": "main.js",
+	"dependencies": {
+		"steal-css": "^1.0.0"
+	},
+	"steal": {
+		"plugins": [
+			"steal-css"
+		]
+	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -77,7 +77,6 @@ describe("inferred from source content", function(){
 });
 
 describe("provided as a glob", function(){
-
 	before(function(done){
 		rimraf(__dirname + "/basics/dist").then(function(){
 			this.buildPromise = stealTools.build({
@@ -107,5 +106,35 @@ describe("provided as a glob", function(){
 	it("infer: false prevents copying of css images", function(){
 		assert(!exists(__dirname + "/basics/dist/images"), "images not copied");
 	});
-
 });
+
+describe("when globbing a directory that contains files", function(){
+	before(function(done){
+		rimraf(__dirname + "/basics/dist").then(function(){
+			this.buildPromise = stealTools.build({
+				config: __dirname + "/basics/package.json!npm"
+			}, {
+				quiet: true
+			});
+
+			this.bundlePromise = this.buildPromise.then(function(buildResult){
+				return bundleAssets(buildResult, {
+					infer: false,
+					glob: "test/basics/docs/**"
+				});
+			});
+
+			return this.bundlePromise;
+		}.bind(this)).then(function(){
+			done();
+		}, function(err){
+			assert(!err, err.message);
+			done();
+		});
+	});
+
+	it("JSON file was copied over", function(){
+		assert(exists(__dirname + "/basics/dist/docs/hello.json"), "doc copied");
+	});
+});
+


### PR DESCRIPTION
This prevents matching directories using the double star `**` option.
This can cause race conditions where it tries to copy a file in the
directory at the same time it is copying the directory itself, so one of
the two will fail as the file is locked.

Closes #16